### PR TITLE
fix: multi text response

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,13 @@
 ## Unreleased
 
+## 0.4.5 [2025-07-14]
+
 ### Added
 - Add `with` configuration, as `with_` function, to graph traversal
 
 ### Fixes
 - Properly handle `:pong` response for long-lived requests
+- Support for multiple responses blocks in a single websocket response
 
 ## 0.4.4 [2025-06-12]
 

--- a/README.md
+++ b/README.md
@@ -2,6 +2,8 @@
 
 [![CI](https://github.com/coingaming/gremlex/actions/workflows/ci.yaml/badge.svg)](https://github.com/coingaming/gremlex/actions/workflows/ci.yaml)
 [![License: MIT](https://img.shields.io/badge/License-MIT-yellow.svg)](https://opensource.org/licenses/MIT)
+[![Version](https://img.shields.io/hexpm/v/gremlex.svg)](https://hex.pm/packages/gremlex)
+[![Docs](https://img.shields.io/badge/documentation-gray.svg)](https://hexdocs.pm/gremlex)
 
 # Gremlex
 
@@ -16,7 +18,7 @@ Install from Hex.pm:
 ```elixir
 def deps do
   [
-    {:gremlex, "~> 0.4.4"}
+    {:gremlex, "~> 0.4.5"}
   ]
 end
 ```

--- a/lib/gremlex/client.ex
+++ b/lib/gremlex/client.ex
@@ -292,13 +292,20 @@ defmodule Gremlex.Client do
     send_frame(state, {:pong, ""})
   end
 
-  # Single block response
-  defp handle_decoded_response(state, [{:text, query_result}], conn, timeout, acc) do
-    response = Jason.decode!(query_result)
-    result = Deserializer.deserialize(response)
-    status = response["status"]["code"]
-    error_message = response["status"]["message"]
-    # Continue to block until we receive a 200 status code
+  defp handle_decoded_response(state, [{:text, _} = _rest] = response, conn, timeout, acc) do
+    responses = response |> Keyword.get_values(:text) |> Enum.map(&Jason.decode!/1)
+    results = Enum.map(responses, &Deserializer.deserialize/1)
+    status = responses |> Enum.map(& &1["status"]["code"]) |> Enum.min()
+    error_message = Enum.map_join(responses, ", ", & &1["status"]["message"])
+
+    result =
+      case results do
+        # If we received a single response then do not convert to list. Otherwise maps
+        # and other non-list types would be returned as lists
+        [r] -> r
+        many -> many
+      end
+
     case status do
       200 -> {:ok, acc ++ result}
       204 -> {:ok, []}
@@ -310,28 +317,6 @@ defmodule Gremlex.Client do
       597 -> {:error, :SCRIPT_EVALUATION_ERROR, error_message}
       598 -> {:error, :SERVER_TIMEOUT, error_message}
       599 -> {:error, :SERVER_SERIALIZATION_ERROR, error_message}
-    end
-  end
-
-  # Multiple block response. In some cases we can receive a single response
-  # containing multiple 206 blocks and a final 200 block
-  defp handle_decoded_response(state, [{:text, _} | _rest] = response, conn, timeout, acc) do
-    responses = response |> Keyword.get_values(:text) |> Enum.map(&Jason.decode!/1)
-    statuses = MapSet.new(responses, & &1["status"]["code"])
-    results = Enum.map(responses, &Deserializer.deserialize/1)
-    error_message = Enum.map_join(responses, ", ", & &1["status"]["error_message"])
-
-    cond do
-      200 in statuses -> {:ok, acc ++ results}
-      204 in statuses -> {:ok, []}
-      206 in statuses -> recv(Map.put(state, :conn, conn), timeout, acc ++ results)
-      401 in statuses -> {:error, :UNAUTHORIZED, error_message}
-      409 in statuses -> {:error, :MALFORMED_REQUEST, error_message}
-      499 in statuses -> {:error, :INVALID_REQUEST_ARGUMENTS, error_message}
-      500 in statuses -> {:error, :SERVER_ERROR, error_message}
-      597 in statuses -> {:error, :SCRIPT_EVALUATION_ERROR, error_message}
-      598 in statuses -> {:error, :SERVER_TIMEOUT, error_message}
-      599 in statuses -> {:error, :SERVER_SERIALIZATION_ERROR, error_message}
     end
   end
 

--- a/lib/gremlex/client.ex
+++ b/lib/gremlex/client.ex
@@ -292,7 +292,7 @@ defmodule Gremlex.Client do
     send_frame(state, {:pong, ""})
   end
 
-  defp handle_decoded_response(state, [{:text, _} = _rest] = response, conn, timeout, acc) do
+  defp handle_decoded_response(state, [{:text, _} | _rest] = response, conn, timeout, acc) do
     responses = response |> Keyword.get_values(:text) |> Enum.map(&Jason.decode!/1)
     results = Enum.map(responses, &Deserializer.deserialize/1)
     status = responses |> Enum.map(& &1["status"]["code"]) |> Enum.min()

--- a/lib/gremlex/client.ex
+++ b/lib/gremlex/client.ex
@@ -316,7 +316,7 @@ defmodule Gremlex.Client do
   # Multiple block response. In some cases we can receive a single response
   # containing multiple 206 blocks and a final 200 block
   defp handle_decoded_response(state, [{:text, _} | _rest] = response, conn, timeout, acc) do
-    responses = response |> Keyword.values() |> Enum.map(&Jason.decode!/1)
+    responses = response |> Keyword.get_values(:text) |> Enum.map(&Jason.decode!/1)
     statuses = MapSet.new(responses, & &1["status"]["code"])
     results = Enum.map(responses, &Deserializer.deserialize/1)
     error_message = Enum.map_join(responses, ", ", & &1["status"]["error_message"])

--- a/lib/gremlex/client.ex
+++ b/lib/gremlex/client.ex
@@ -278,35 +278,60 @@ defmodule Gremlex.Client do
        ) do
     with {:ok, conn2, [{:data, ^ref, data}]} <- Mint.WebSocket.recv(conn, 0, timeout),
          {:ok, _websocket, result} <- Mint.WebSocket.decode(websocket, data) do
-      case result do
-        [{:text, query_result}] ->
-          response = Jason.decode!(query_result)
-          result = Deserializer.deserialize(response)
-          status = response["status"]["code"]
-          error_message = response["status"]["message"]
-          # Continue to block until we receive a 200 status code
-          case status do
-            200 -> {:ok, acc ++ result}
-            204 -> {:ok, []}
-            206 -> recv(Map.put(state, :conn, conn2), timeout, acc ++ result)
-            401 -> {:error, :UNAUTHORIZED, error_message}
-            409 -> {:error, :MALFORMED_REQUEST, error_message}
-            499 -> {:error, :INVALID_REQUEST_ARGUMENTS, error_message}
-            500 -> {:error, :SERVER_ERROR, error_message}
-            597 -> {:error, :SCRIPT_EVALUATION_ERROR, error_message}
-            598 -> {:error, :SERVER_TIMEOUT, error_message}
-            599 -> {:error, :SERVER_SERIALIZATION_ERROR, error_message}
-          end
+      handle_decoded_response(state, result, conn2, timeout, acc)
+    end
+  end
 
-        [{:pong, _}] ->
-          # No need to schedule :ping messages since they are periodically scheduled
-          :ok
+  # No need to schedule ping message again since they are periodically scheduled
+  defp handle_decoded_response(_state, [{:pong, _}], _conn, _timeout, _acc) do
+    :ok
+  end
 
-        [{:ping, _}] ->
-          # Keep the connection alive
-          send_frame(state, {:pong, ""})
-          :ok
-      end
+  # Keep the connection alive
+  defp handle_decoded_response(state, [{:ping, _}], _conn, _timeout, _acc) do
+    send_frame(state, {:pong, ""})
+  end
+
+  # Single block response
+  defp handle_decoded_response(state, [{:text, query_result}], conn, timeout, acc) do
+    response = Jason.decode!(query_result)
+    result = Deserializer.deserialize(response)
+    status = response["status"]["code"]
+    error_message = response["status"]["message"]
+    # Continue to block until we receive a 200 status code
+    case status do
+      200 -> {:ok, acc ++ result}
+      204 -> {:ok, []}
+      206 -> recv(Map.put(state, :conn, conn), timeout, acc ++ result)
+      401 -> {:error, :UNAUTHORIZED, error_message}
+      409 -> {:error, :MALFORMED_REQUEST, error_message}
+      499 -> {:error, :INVALID_REQUEST_ARGUMENTS, error_message}
+      500 -> {:error, :SERVER_ERROR, error_message}
+      597 -> {:error, :SCRIPT_EVALUATION_ERROR, error_message}
+      598 -> {:error, :SERVER_TIMEOUT, error_message}
+      599 -> {:error, :SERVER_SERIALIZATION_ERROR, error_message}
+    end
+  end
+
+  # Multiple block response. In some cases we can receive a single response
+  # containing multiple 206 blocks and a final 200 block
+  defp handle_decoded_response(state, [{:text, _} | _rest] = response, conn, timeout, acc) do
+    responses = response |> Keyword.values() |> Enum.map(&Jason.decode!/1)
+    statuses = MapSet.new(responses, & &1["status"]["code"])
+    results = Enum.map(responses, &Deserializer.deserialize/1)
+    error_message = Enum.map_join(responses, ", ", & &1["status"]["error_message"])
+
+    cond do
+      200 in statuses -> {:ok, acc ++ results}
+      204 in statuses -> {:ok, []}
+      206 in statuses -> recv(Map.put(state, :conn, conn), timeout, acc ++ results)
+      401 in statuses -> {:error, :UNAUTHORIZED, error_message}
+      409 in statuses -> {:error, :MALFORMED_REQUEST, error_message}
+      499 in statuses -> {:error, :INVALID_REQUEST_ARGUMENTS, error_message}
+      500 in statuses -> {:error, :SERVER_ERROR, error_message}
+      597 in statuses -> {:error, :SCRIPT_EVALUATION_ERROR, error_message}
+      598 in statuses -> {:error, :SERVER_TIMEOUT, error_message}
+      599 in statuses -> {:error, :SERVER_SERIALIZATION_ERROR, error_message}
     end
   end
 

--- a/lib/gremlex/client.ex
+++ b/lib/gremlex/client.ex
@@ -292,20 +292,13 @@ defmodule Gremlex.Client do
     send_frame(state, {:pong, ""})
   end
 
-  defp handle_decoded_response(state, [{:text, _} | _rest] = response, conn, timeout, acc) do
-    responses = response |> Keyword.get_values(:text) |> Enum.map(&Jason.decode!/1)
-    results = Enum.map(responses, &Deserializer.deserialize/1)
-    status = responses |> Enum.map(& &1["status"]["code"]) |> Enum.min()
-    error_message = Enum.map_join(responses, ", ", & &1["status"]["message"])
-
-    result =
-      case results do
-        # If we received a single response then do not convert to list. Otherwise maps
-        # and other non-list types would be returned as lists
-        [r] -> r
-        many -> many
-      end
-
+  # Single block response
+  defp handle_decoded_response(state, [{:text, query_result}], conn, timeout, acc) do
+    response = Jason.decode!(query_result)
+    result = Deserializer.deserialize(response)
+    status = response["status"]["code"]
+    error_message = response["status"]["message"]
+    # Continue to block until we receive a 200 status code
     case status do
       200 -> {:ok, acc ++ result}
       204 -> {:ok, []}
@@ -317,6 +310,28 @@ defmodule Gremlex.Client do
       597 -> {:error, :SCRIPT_EVALUATION_ERROR, error_message}
       598 -> {:error, :SERVER_TIMEOUT, error_message}
       599 -> {:error, :SERVER_SERIALIZATION_ERROR, error_message}
+    end
+  end
+
+  # Multiple block response. In some cases we can receive a single response
+  # containing multiple 206 blocks and a final 200 block
+  defp handle_decoded_response(state, [{:text, _} | _rest] = response, conn, timeout, acc) do
+    responses = response |> Keyword.get_values(:text) |> Enum.map(&Jason.decode!/1)
+    statuses = MapSet.new(responses, & &1["status"]["code"])
+    results = Enum.map(responses, &Deserializer.deserialize/1)
+    error_message = Enum.map_join(responses, ", ", & &1["status"]["error_message"])
+
+    cond do
+      200 in statuses -> {:ok, acc ++ results}
+      204 in statuses -> {:ok, []}
+      206 in statuses -> recv(Map.put(state, :conn, conn), timeout, acc ++ results)
+      401 in statuses -> {:error, :UNAUTHORIZED, error_message}
+      409 in statuses -> {:error, :MALFORMED_REQUEST, error_message}
+      499 in statuses -> {:error, :INVALID_REQUEST_ARGUMENTS, error_message}
+      500 in statuses -> {:error, :SERVER_ERROR, error_message}
+      597 in statuses -> {:error, :SCRIPT_EVALUATION_ERROR, error_message}
+      598 in statuses -> {:error, :SERVER_TIMEOUT, error_message}
+      599 in statuses -> {:error, :SERVER_SERIALIZATION_ERROR, error_message}
     end
   end
 

--- a/mix.exs
+++ b/mix.exs
@@ -2,7 +2,7 @@ defmodule Gremlex.MixProject do
   use Mix.Project
 
   @source_url "https://github.com/coingaming/gremlex"
-  @version "0.4.4"
+  @version "0.4.5"
 
   def project do
     [


### PR DESCRIPTION
## Description
It is possible in some databases to receive a single response composed of multiple responses.

These have the form `[text: response1, text: response2, ..., text: responseN]` where:

- All the `response` contain the same `requestId`
- `status.code` is 206 for response1, response2, ... except for responseN which is 200